### PR TITLE
Change wssu namespace to wsu

### DIFF
--- a/src/Created.php
+++ b/src/Created.php
@@ -8,7 +8,7 @@ class Created extends Element
 {
     public const NAME = 'Created';
 
-    public function __construct(int $timestamp, string $namespace = self::NS_WSSU)
+    public function __construct(int $timestamp, string $namespace = self::NS_WSU)
     {
         $this->setTimestampValue($timestamp);
         parent::__construct(self::NAME, $namespace, $this->getTimestampValue(true));

--- a/src/Element.php
+++ b/src/Element.php
@@ -19,9 +19,19 @@ class Element
 
     public const NS_WSSE_NAME = 'wsse';
 
+    /**
+     * @deprecated
+     */
     public const NS_WSSU = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd';
 
+    public const NS_WSU = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd';
+
+    /**
+     * @deprecated
+     */
     public const NS_WSSU_NAME = 'wssu';
+
+    public const NS_WSU_NAME = 'wsu';
 
     protected string $name = '';
 
@@ -262,10 +272,10 @@ class Element
 
         foreach ($this->getAttributes() as $attributeName => $attributeValue) {
             $matches = [];
-            if (0 === preg_match(sprintf('/(%s|%s):/', self::NS_WSSU_NAME, self::NS_WSSE_NAME), $attributeName, $matches)) {
+            if (0 === preg_match(sprintf('/(%s|%s):/', self::NS_WSU_NAME, self::NS_WSSE_NAME), $attributeName, $matches)) {
                 $element->setAttribute($attributeName, (string) $attributeValue);
             } else {
-                $element->setAttributeNS(self::NS_WSSE_NAME === $matches[1] ? self::NS_WSSE : self::NS_WSSU, $attributeName, $attributeValue);
+                $element->setAttributeNS(self::NS_WSSE_NAME === $matches[1] ? self::NS_WSSE : self::NS_WSU, $attributeName, $attributeValue);
             }
         }
 
@@ -290,8 +300,8 @@ class Element
 
                 break;
 
-            case self::NS_WSSU:
-                $namespacePrefix = self::NS_WSSU_NAME;
+            case self::NS_WSU:
+                $namespacePrefix = self::NS_WSU_NAME;
 
                 break;
         }

--- a/src/Expires.php
+++ b/src/Expires.php
@@ -8,7 +8,7 @@ class Expires extends Element
 {
     public const NAME = 'Expires';
 
-    public function __construct(int $timestamp, int $expiresIn = 3600, string $namespace = self::NS_WSSU)
+    public function __construct(int $timestamp, int $expiresIn = 3600, string $namespace = self::NS_WSU)
     {
         $this->setTimestampValue($timestamp + $expiresIn);
         parent::__construct(self::NAME, $namespace, $this->getTimestampValue(true));

--- a/src/Timestamp.php
+++ b/src/Timestamp.php
@@ -14,7 +14,7 @@ class Timestamp extends Element
 
     protected ?Expires $expires;
 
-    public function __construct(string $namespace = self::NS_WSSU)
+    public function __construct(string $namespace = self::NS_WSU)
     {
         parent::__construct(self::NAME, $namespace);
     }

--- a/src/UsernameToken.php
+++ b/src/UsernameToken.php
@@ -23,7 +23,7 @@ class UsernameToken extends Element
     public function __construct(?string $id = null, string $namespace = self::NS_WSSE)
     {
         parent::__construct(self::NAME, $namespace, null, empty($id) ? [] : [
-            sprintf('%s:%s', parent::NS_WSSU_NAME, self::ATTRIBUTE_ID) => $id,
+            sprintf('%s:%s', parent::NS_WSU_NAME, self::ATTRIBUTE_ID) => $id,
         ]);
     }
 

--- a/tests/WsSecurityTest.php
+++ b/tests/WsSecurityTest.php
@@ -22,13 +22,13 @@ final class WsSecurityTest extends TestCase
             <wsse:UsernameToken>
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
-            <wssu:Timestamp xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
-                <wssu:Created>2016-03-31T19:17:04Z</wssu:Created>
-                <wssu:Expires>2016-03-31T19:27:04Z</wssu:Expires>
-            </wssu:Timestamp>
+            <wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+                <wsu:Created>2016-03-31T19:17:04Z</wsu:Created>
+                <wsu:Expires>2016-03-31T19:27:04Z</wsu:Expires>
+            </wsu:Timestamp>
         </wsse:Security>'), $header->data->enc_value);
     }
 
@@ -41,7 +41,7 @@ final class WsSecurityTest extends TestCase
             <wsse:UsernameToken>
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->data->enc_value);
@@ -56,7 +56,7 @@ final class WsSecurityTest extends TestCase
             <wsse:UsernameToken>
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->data->enc_value);
@@ -71,7 +71,7 @@ final class WsSecurityTest extends TestCase
             <wsse:UsernameToken>
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->data->enc_value);
@@ -86,7 +86,7 @@ final class WsSecurityTest extends TestCase
             <wsse:UsernameToken>
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->enc_value);
@@ -101,7 +101,7 @@ final class WsSecurityTest extends TestCase
             <wsse:UsernameToken>
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">([a-zA-Z0-9=/+]*)</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->enc_value);
@@ -113,10 +113,10 @@ final class WsSecurityTest extends TestCase
         $this->assertInstanceOf(SoapHeader::class, $header);
         $this->assertMatches(self::innerTrim('
         <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustunderstand="1" SOAP-ENV:actor="BAR">
-            <wsse:UsernameToken xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wssu:Id="X90I3u8">
+            <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="X90I3u8">
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->data->enc_value);
@@ -128,10 +128,10 @@ final class WsSecurityTest extends TestCase
         $this->assertInstanceOf(SoapHeader::class, $header);
         $this->assertMatches(self::innerTrim('
         <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" SOAP-ENV:mustunderstand="1" SOAP-ENV:actor="BAR">
-            <wsse:UsernameToken xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wssu:Id="X90I3u8">
+            <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="X90I3u8">
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->data->enc_value);
     }
@@ -158,7 +158,7 @@ final class WsSecurityTest extends TestCase
             <wsse:UsernameToken>
                 <wsse:Username>foo</wsse:Username>
                 <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">bar</wsse:Password>
-                <wssu:Created xmlns:wssu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wssu:Created>
+                <wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-03-31T19:17:04Z</wsu:Created>
                 <wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">([a-zA-Z0-9=]*)</wsse:Nonce>
             </wsse:UsernameToken>
         </wsse:Security>'), $header->data->enc_value);


### PR DESCRIPTION
According to this [document](https://docs.oasis-open.org/wss/v1.1/wss-v1.1-spec-errata-os-SOAPMessageSecurity.htm#_Toc118717115), the legal namespace should be `wsu` instead of `wssu`.
